### PR TITLE
hotfix: remove failing @verifd/shared import in success page

### DIFF
--- a/OPS/HANDOFF_HISTORY.md
+++ b/OPS/HANDOFF_HISTORY.md
@@ -860,3 +860,70 @@ Asks for PM:
 - Approve or request changes based on diff/test tails; if unclear, ask Claude to regenerate via /handoff:prep.
 
 ---END-HANDOFF---
+
+
+## 2025-08-14T01:57:44Z
+
+---HANDOFF---
+Task: (auto) Fallback handoff — assistant reply had no explicit ---HANDOFF---
+When: 2025-08-14T01:57:44Z
+Branch: main
+
+Diff Summary:
+ OPS/LAST_HANDOFF.txt | 130 ++++++++++++++++++++-------------------------------
+ 1 file changed, 51 insertions(+), 79 deletions(-)
+
+Files Touched:
+OPS/LAST_HANDOFF.txt
+
+Last Commit:
+6030714 fix(web-verify): configure Vercel build for monorepo workspace resolution
+
+Commands/Tests Run (tail):
+
+> @verifd/backend@0.1.0 test /Users/harshilpatel/Desktop/Claude_Projects/verifd/apps/backend
+> vitest
+
+[33mThe CJS build of Vite's Node API is deprecated. See https://vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.[39m
+
+ DEV  v2.1.9 /Users/harshilpatel/Desktop/Claude_Projects/verifd/apps/backend
+
+ ✓ test/pass.check.simple.test.ts (6 tests | 1 skipped) 2ms
+stdout | test/pass.check.mock.test.ts > GET /pass/check - Integration Tests (Mocked) > returns allowed=false for unknown number
+[DEBUG] No active pass found for number: ph_8a59780bb8cd2ba0
+
+stdout | test/pass.check.mock.test.ts > GET /pass/check - Integration Tests (Mocked) > returns allowed=true for active pass
+[INFO] Active pass found for number: ph_8a59780bb8cd2ba0, expires: 1754771816
+
+stdout | test/pass.check.mock.test.ts > GET /pass/check - Integration Tests (Mocked) > returns allowed=false for expired pass
+[DEBUG] No active pass found for number: ph_8a59780bb8cd2ba0
+
+stdout | test/pass.check.mock.test.ts > GET /pass/check - Integration Tests (Mocked) > includes Cache-Control header
+[DEBUG] No active pass found for number: ph_8a59780bb8cd2ba0
+
+stdout | test/pass.check.mock.test.ts > GET /pass/check - Integration Tests (Mocked) > correctly identifies 30m scope
+[INFO] Active pass found for number: ph_f5be76815beedc12, expires: 1754770016
+
+stdout | test/pass.check.mock.test.ts > GET /pass/check - Integration Tests (Mocked) > correctly identifies 30d scope
+[INFO] Active pass found for number: ph_554285f82182d3dd, expires: 1757360216
+
+ ✓ test/pass.check.mock.test.ts (7 tests) 65ms
+
+ Test Files  2 passed (2)
+      Tests  12 passed | 1 skipped (13)
+   Start at  15:36:55
+   Duration  378ms (transform 78ms, setup 0ms, collect 174ms, tests 67ms, environment 0ms, prepare 106ms)
+
+ PASS  Waiting for file changes...
+       press h to show help, press q to quit
+
+Playwright (tail):
+
+
+Open Risks:
+- Auto-generated handoff; ask Claude to run /handoff:prep next time for richer details.
+
+Asks for PM:
+- Approve or request changes based on diff/test tails; if unclear, ask Claude to regenerate via /handoff:prep.
+
+---END-HANDOFF---

--- a/OPS/LAST_HANDOFF.txt
+++ b/OPS/LAST_HANDOFF.txt
@@ -1,34 +1,17 @@
 ---HANDOFF---
-Task: verifd – Zod row typing + health/metrics documentation
-When: 2025-08-10T17:49:00Z
-Branch: feat/zod-row-typing
+Task: (auto) Fallback handoff — assistant reply had no explicit ---HANDOFF---
+When: 2025-08-14T01:57:44Z
+Branch: main
 
 Diff Summary:
- HANDOFF.md                        | 137 +++++-----
- OPS/HANDOFF_HISTORY.md            | 536 ++++++++++++++++++++++++++++++++++++++
- OPS/LAST_HANDOFF.txt              |  30 +--
- apps/backend/src/routes/health.ts |   7 +-
- apps/backend/src/server.ts        |   5 +-
- 5 files changed, 613 insertions(+), 102 deletions(-)
+ OPS/LAST_HANDOFF.txt | 130 ++++++++++++++++++++-------------------------------
+ 1 file changed, 51 insertions(+), 79 deletions(-)
 
 Files Touched:
-HANDOFF.md
-OPS/HANDOFF_HISTORY.md
 OPS/LAST_HANDOFF.txt
-apps/backend/src/routes/health.ts
-apps/backend/src/server.ts
 
 Last Commit:
-c94af3f typing: Zod-validate DB rows in pass.ts & verify.ts; fix SELECTs
-
-## Today's Summary (2025-08-10)
-- Branch created: feat/zod-row-typing (pushed to GitHub)
-- DB path fix: var/db/verifd.sqlite with auto-mkdir
-- Zod typing: DB rows validated at query boundaries in pass.ts and verify.ts
-- Health aliases: /health, /health/health, /healthz all working
-- PORT support: Backend respects PORT env variable (default 3000)
-- Metrics: Available at /health/metrics (not /metrics)
-- TypeScript: Build passes with zero errors
+6030714 fix(web-verify): configure Vercel build for monorepo workspace resolution
 
 Commands/Tests Run (tail):
 

--- a/apps/web-verify/app/success/page.tsx
+++ b/apps/web-verify/app/success/page.tsx
@@ -2,7 +2,12 @@
 
 import { useState, useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
-import type { PassCheckResponse } from '@verifd/shared';
+// TODO: Revert to `import type { PassCheckResponse } from '@verifd/shared'` after proper package exports
+type PassCheckResponse = { 
+  allowed: boolean; 
+  scope?: '30m' | '24h' | '30d'; 
+  expires_at?: string;
+};
 
 interface PassCheckState {
   loading: boolean;


### PR DESCRIPTION
## Summary
This PR removes the failing `@verifd/shared` import that's blocking CI and Vercel builds.

## Changes
- Replace `import type { PassCheckResponse } from '@verifd/shared'` with a local type alias
- Add TODO comment to restore proper import after package exports are configured

## Why This Works
The build was failing because the shared package doesn't have proper exports configured. This hotfix uses a local type definition to unblock builds immediately while we work on the proper package configuration.

## Next Steps
After this merges, we'll implement proper package exports for `@verifd/shared` with build tooling (tsup) and restore the import.

## Testing
The build now compiles successfully past TypeScript checking:
```
✓ Compiled successfully
✓ Linting and checking validity of types
```

The remaining errors are unrelated runtime issues with useSearchParams that were already present.